### PR TITLE
Fix for unmatched sku

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,6 @@ app.get("/", (req, res) =>
 
 // Functions to perform transaction with Stripe
 function buyGiftCard(form, callback) {
-  //console.log(form);
   getSkuList((err, skuList) => {
     if (err) {}
     chooseSku(form, skuList, (err, chosenSku) => {
@@ -51,7 +50,7 @@ function buyGiftCard(form, callback) {
 
 function getSkuList(callback) {
   stripe.skus.list({
-    limit: 30
+    limit: 100
   }, function(err, skus) {
       if (err) {}
       callback(null, skus);
@@ -226,7 +225,7 @@ function mailchimpAddSub(order) {
     })
     .end(function(err, response) {
       if (response.status < 300 || (response.status === 400 && response.body.title === "Member Exists")) {
-        console.log('Mailchimp: Subscription sucessful.');
+        console.log('Mailchimp: Subscription successful.');
       } else {
         console.log('Mailchimp: Subscription failed.');
       }

--- a/public/giftcard.js
+++ b/public/giftcard.js
@@ -2,25 +2,25 @@ $( document ).ready(function() {
 
   // TESTING ONLY: FORM AUTO FILL
 
-  // $('[name="customer_name"]').val("John Smith");
-  // $('[name="from_name"]').val("John Smith");
-  // $('[name="customer_phone"]').val("2064567890");
-  // $('[name="recipient_name"]').val("Jane Doe");
-  // $('[name="recipient_message"]').val("Just for being great and all.");
-  // $('#ShipToPickup').prop("checked", true);
-  // $('[name="shipping_address_line1"]').val("171 Lake Washington Blvd E");
+  // $('[name="customer_name"]').val("Jeremy Beasley");
+  // $('[name="from_name"]').val("Jeremy");
+  // $('[name="customer_phone"]').val("2065125877");
+  // $('[name="recipient_name"]').val("Jane");
+  // $('[name="recipient_message"]').val("Ignore this transaction. Testing.");
+  // $('#ShipToMe').prop("checked", true);
+  // $('[name="shipping_address_line1"]').val("828 26th Ave S.");
   // $('[name="shipping_address_line2"]').val("");
   // $('[name="shipping_address_city"]').val("Seattle");
   // $('[name="shipping_address_state"]').val("Washington");
   // $('[name="shipping_address_country"]').val("United States");
-  // $('[name="shipping_address_postal_code"]').val("98112");
+  // $('[name="shipping_address_postal_code"]').val("98144");
   // $('[name="stripeEmail"]').val("jeremy@bsley.com");
-  // $('#cc').val("4242424242424242");
-  // $('#ccm').val("12");
-  // $('#ccy').val("19");
-  // $('#cvv').val("123");
+  // $('#cc').val("4079413305630405");
+  // $('#ccm').val("09");
+  // $('#ccy').val("20");
+  // $('#cvv').val("550");
   // $('.FormItem').addClass("active");
-  // $('.InputGiftAmount').val("123");
+  // $('.InputGiftAmount').val("3");
 
   // Populates "You will be charged.." dialogue before submit button
 

--- a/public/giftcard.js
+++ b/public/giftcard.js
@@ -4,21 +4,21 @@ $( document ).ready(function() {
 
   // $('[name="customer_name"]').val("Jeremy Beasley");
   // $('[name="from_name"]').val("Jeremy");
-  // $('[name="customer_phone"]').val("2065125877");
+  // $('[name="customer_phone"]').val("2061234567");
   // $('[name="recipient_name"]').val("Jane");
   // $('[name="recipient_message"]').val("Ignore this transaction. Testing.");
   // $('#ShipToMe').prop("checked", true);
-  // $('[name="shipping_address_line1"]').val("828 26th Ave S.");
+  // $('[name="shipping_address_line1"]').val("800 26th Ave S.");
   // $('[name="shipping_address_line2"]').val("");
   // $('[name="shipping_address_city"]').val("Seattle");
   // $('[name="shipping_address_state"]').val("Washington");
   // $('[name="shipping_address_country"]').val("United States");
   // $('[name="shipping_address_postal_code"]').val("98144");
   // $('[name="stripeEmail"]').val("jeremy@bsley.com");
-  // $('#cc').val("4079413305630405");
+  // $('#cc').val("4242424242424242");
   // $('#ccm').val("09");
-  // $('#ccy').val("20");
-  // $('#cvv').val("550");
+  // $('#ccy').val("24");
+  // $('#cvv').val("123");
   // $('.FormItem').addClass("active");
   // $('.InputGiftAmount').val("3");
 


### PR DESCRIPTION
We had a failing error in prod where someone would enter an amount for a card that had already been purchased. Since each unique price has it's own unique sku, we have to either match one or create a new one. Since the limit was 30 in `app.js` and we now have more than 30 unique prices/skus, it was failing. I've increased this limit to 100.